### PR TITLE
Add controllers to web ignore Authentication. Development process without token

### DIFF
--- a/src/main/java/com/it_academyproject/jwt_security/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/it_academyproject/jwt_security/configuration/SecurityConfiguration.java
@@ -79,8 +79,14 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter
     @Override
     public void configure (WebSecurity web) throws Exception
     {
-        web.ignoring()
-                .antMatchers("/api/public/**" , "/api/get-reset-email/**" , "/api/save-new-password/**");
+    //Original web ignoring. Expose only /public for data importer, and get/save pass
+//    	web.ignoring()
+//                .antMatchers("/api/public/**" , "/api/get-reset-email/**" , "/api/save-new-password/**");
+    
+    //B-17 task. Add to web.ignoring controllers used during development to avoid asking for a Token during dev
+    	//Add endpoints when new controller is added in the API
+    	web.ignoring()
+        .antMatchers("/api/public/**" , "/api/get-reset-email/**" , "/api/save-new-password/**" , "/api/students/**" , "/api/statistics/**" , "/api/userExercise/**");
     }
 
 


### PR DESCRIPTION
-In WebSecurity configuration add /students, /statistics and
/userExcercise to the list of controllers that dont need athentication
-This is done to avoid requesting token for each request during
development process
-Keep the original line of web.ignore to easily go back to original
secured API.